### PR TITLE
Fix missing header for PHP >= 8.4

### DIFF
--- a/varnish_lib.c
+++ b/varnish_lib.c
@@ -40,7 +40,6 @@
 
 #ifdef PHP_WIN32
 #undef UNICODE
-#include "win32/inet.h"
 #include <winsock2.h>
 #include <windows.h>
 #include <Ws2tcpip.h>


### PR DESCRIPTION
The inet_aton on Windows and its header win32/inet.h have been removed in PHP-8.4-dev. I'm only noting this change via this PR since the winsock2.h and Ws2tcpip.h are already included properly.